### PR TITLE
Add demo validation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # AGI-EGGS
-Framework that use Unified Universal Language Protocol to Process information that centers on fact through math and psychology
+
+This repository contains a minimal prototype demonstrating a simple
+"validation protocol" inspired by the Φ-Calculus concept. The script
+`validation_protocol.py` generates synthetic tensors, applies small
+perturbations, and measures whether the predicted boundary response
+correlates with the observed system behavior.
+
+## Running the demo
+1. Install the only dependency (NumPy):
+   ```bash
+   pip install numpy --user
+   ```
+2. Execute the script:
+   ```bash
+   python3 validation_protocol.py
+   ```
+The script prints the correlation between predicted and measured Φ values
+across multiple trials.

--- a/validation_protocol.py
+++ b/validation_protocol.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+"""Simple demonstration of a validation protocol for Φ-Calculus.
+This script generates synthetic data to test whether the system's
+response to perturbations correlates with predicted Φ values.
+"""
+
+np.random.seed(0)
+P = np.random.randn(10)
+V = np.random.randn(10)
+
+
+def adversarial_perturbation(P):
+    """Return a small perturbation of P."""
+    noise = np.random.normal(scale=0.1, size=P.shape)
+    return P + noise
+
+
+class SimpleSystem:
+    def propagate(self, probe):
+        """Simple linear propagation with noise."""
+        noise = np.random.normal(scale=0.05, size=probe.shape)
+        return probe + noise
+
+
+system = SimpleSystem()
+
+num_trials = 100
+phi_predicted_values = []
+phi_measured_values = []
+
+for _ in range(num_trials):
+    probe = adversarial_perturbation(P)
+    response = system.propagate(probe)
+    phi_predicted_values.append(np.dot(probe, V))
+    phi_measured_values.append(np.dot(response, V))
+
+correlation = np.corrcoef(phi_predicted_values, phi_measured_values)[0, 1]
+
+print(f"Correlation across {num_trials} trials: {correlation:.3f}")
+print("Validation passed" if correlation > 0.9 else "Validation failed")


### PR DESCRIPTION
## Summary
- add a small prototype script `validation_protocol.py`
- update README with instructions on running the demo

## Testing
- `python3 validation_protocol.py`
- `python3 -m py_compile validation_protocol.py`

------
https://chatgpt.com/codex/tasks/task_e_687e564fec608324bbf9221ee3bff607